### PR TITLE
[#30] chore: Set up Jest and Playwright testing frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/RULES.md
+++ b/RULES.md
@@ -64,9 +64,10 @@ PackRight follows a highly organized Next.js App Router structure. Separating se
 **Methodology:** Test-Driven Development (TDD) is required. Ensure minimum **70% test code coverage** across the project.
 
 - **Feature Implementation Checkpoint**: For every feature requested via a GitHub issue, you must evaluate the acceptance criteria and proactively generate as many robust test cases as possible using **Jest** (not Vitest). Implementation cannot be marked as "completed" until all generated Jest test cases successfully pass.
-- **Unit Tests (Jest)**: Used for isolated business logic, database query wrappers, and utility functions (e.g., testing the Group Readiness percentage calculation). All files must end in `.test.ts`.
+- **Unit Tests (Jest)**: Used for isolated business logic, database query wrappers, and utility functions (e.g., testing the Group Readiness percentage calculation). All files must end in `.test.ts` or `.test.tsx` and reside in `/tests/unit/`.
+- **Integration Tests (Jest)**: Used for evaluating connected React Components spanning multiple features or simulating back-end interaction via mocked APIs (e.g., MSW). All files must end in `.test.tsx` or `.test.ts` and reside in `/tests/integration/`.
 - **E2E Tests (Playwright)**: Used to validate critical user flows (e.g., Logging in, creating a trip, utilizing the drag-and-drop board). All files must reside in the `/tests/e2e/` root directory.
-- **CI Blocker**: Every Pull Request must pass the automated GitHub Actions pipeline. The PR **cannot be merged** if unit tests fail, E2E tests fail, or aggregate code coverage drops below 70%.
+- **CI Blocker**: Every Pull Request must pass the automated GitHub Actions pipeline. The PR **cannot be merged** if unit tests fail, integration tests fail, E2E tests fail, or aggregate code coverage drops below 70%.
 
 ---
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from 'jest'
+import nextJest from 'next/jest.js'
+
+const createJestConfig = nextJest({
+    // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+    dir: './',
+})
+
+// Add any custom config to be passed to Jest
+const config: Config = {
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+    testEnvironment: 'jest-environment-jsdom',
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
+}
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+export default createJestConfig(config)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest tests/unit",
+    "test:integration": "jest tests/integration",
+    "test:watch": "jest --watch",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
@@ -24,7 +28,12 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -33,9 +42,12 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "eslint-config-prettier": "^10.1.8",
+    "jest": "^30.2.0",
+    "jest-environment-jsdom": "^30.2.0",
     "prettier": "^3.8.1",
     "shadcn": "^4.0.0",
     "tailwindcss": "^4",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,80 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/tests/e2e/example.spec.ts
+++ b/tests/e2e/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+    await page.goto('http://localhost:3000');
+
+    // We just expect the page to load and not crash.
+    await expect(page).toHaveTitle(/PackRight/i);
+});

--- a/tests/integration/example.test.tsx
+++ b/tests/integration/example.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+
+describe('Dummy Integration Test', () => {
+    it('should render a basic element to verify DOM environment', () => {
+        render(<div data-testid="test-element">Integration Test Ready</div>)
+        expect(screen.getByTestId('test-element')).toBeInTheDocument()
+    })
+})

--- a/tests/unit/example.test.ts
+++ b/tests/unit/example.test.ts
@@ -1,0 +1,5 @@
+describe('Dummy Unit Test', () => {
+    it('should pass', () => {
+        expect(1 + 1).toBe(2)
+    })
+})


### PR DESCRIPTION
Resolves #30

### Description
This PR sets up the testing environments to support a Test-Driven Development (TDD) workflow for the project, per the project rules requiring a minimum 70% coverage.
* **Jest (Unit/Integration):** Configured with `next/jest`, `@testing-library/react`, and custom DOM matchers.
* **Playwright (E2E):** Configured to spin up the local server automatically before executing tests.
* Added standard `test`, `test:integration`, `test:e2e`, and `test:watch` commands to `package.json`.
* Verified that dummy tests pass for both frameworks under local conditions.

### Acceptance Criteria Validated
- [x] Jest testing environment is functional.
- [x] Playwright installed natively and base config (`playwright.config.ts`) is generated.
- [x] A dummy test passes for both frameworks to verify setup.